### PR TITLE
feat: 방향키를 눌렀을 때 타일의 이동이 없고 합쳐진 타일이 없으면 타일추가를 하지 않는다(#37)

### DIFF
--- a/src/app/components/game/TileBox.tsx
+++ b/src/app/components/game/TileBox.tsx
@@ -17,6 +17,7 @@ const TileBox: React.FC = () => {
         .filter((index): index is number => index !== null);
 
       if (emptyIndices.length === 0) {
+        alert("Game Over!");
         return prevTiles; // 빈 칸이 없으면 아무 것도 하지 않음
       }
 
@@ -132,10 +133,14 @@ const TileBox: React.FC = () => {
           newTiles[i + 12] = newColumn[3];
         }
       }
+      // 이동 또는 합쳐짐이 발생했는지 확인
+      const isChanged = JSON.stringify(prevTiles) !== JSON.stringify(newTiles);
+      // 이동이 발생한 경우에만 새로운 타일 추가
+      if (isChanged) {
+        addRandomTile();
+      }
       return newTiles;
     });
-    // 이동 후 랜덤 숫자 추가
-    addRandomTile();
   };
 
   useEffect(() => {


### PR DESCRIPTION
## PR


### ✅ 작업 내용

> 방향키를 눌렀을 때 타일의 이동이 없고 합쳐진 타일이 없으면 타일추가를 하지 않는다
   타일생성이 불가능하면 게임종료 alert 생성( 나중에 모달로 대체 예정 )

### ❗ 유의할 점 및 ETC (선택)

> 유의할 점

### ✨스크린샷 (선택)
